### PR TITLE
fix: start crond and improve reloadcmd for acme.sh cert auto-renewal

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -450,7 +450,7 @@ do
                            --key-file /certs/${!host}/key.pem \
                            --fullchain-file /certs/${!host}/fullchain.pem \
 			   --cert-file /certs/${!host}/cert.pem \
-                           --reloadcmd '/usr/sbin/nginx -s stop && /bin/sleep 5s && /usr/sbin/nginx'
+                           --reloadcmd '/usr/sbin/nginx -s reload'
     touch /certs/${!host}/le-ok
     echo "Let's Encrypt certificate for ${!host} installed."
     echo ""
@@ -471,6 +471,9 @@ echo "Stopping Nginx that was running in daemon mode"
 
 # Sleep a few seconds before starting default Nginx
 /bin/sleep 5s
+
+# Start cron daemon for acme.sh auto-renewal
+/usr/sbin/crond -b -l 8
 
 # Start Nginx
 echo ""


### PR DESCRIPTION
# Changes

## Implementation Details

crond was never started in the container, so acme.sh's cron-based renewal never ran and certs expired. also fixed the reloadcmd from stop+restart (which killed PID 1 and crashed the container) to nginx -s reload (zero-downtime in-place cert reload).

---

# Post-Implementation Validation (If Needed)

## Validation Details

- Validation Date:
  13.05.2026

- Validation Performed By:
  @daverolo 

Security Testing Performed:

- [ ] Yes
- [ ] No
- [ ] N/A
- [x] Manual Testing

## Validation Notes

manual testing performed against acme staging (`NXCT_SERVICE_DRYRUN=true`).

---

# Security Review

- [x] I confirm that I understand and have complied with all requirements outlined in the [Secure Development Guideline](https://rocklogic.sharepoint.com/sites/Intranet#secure-development-guideline).
