### PR TITLE
fix: skip RECOVERED alert if no UNREACHABLE was sent

### DIFF
--- a/upstream_monitor.sh
+++ b/upstream_monitor.sh
@@ -116,11 +116,13 @@ while true; do
 
     if check_upstream "$upstream"; then
       if [ -f "$down_file" ]; then
+        if [ -f "$last_alert_file" ]; then
+          log "[upstream-monitor] RECOVERED: $upstream (serving: $domains)"
+          send_alert "Upstream recovered" \
+            "Upstream $upstream serving $domains on host $HOST_IP is back online." \
+            "00B050"
+        fi
         rm -f "$down_file" "$last_alert_file"
-        log "[upstream-monitor] RECOVERED: $upstream (serving: $domains)"
-        send_alert "Upstream recovered" \
-          "Upstream $upstream serving $domains on host $HOST_IP is back online." \
-          "00B050"
       fi
     else
       now=$(date +%s)


### PR DESCRIPTION
# Changes

## Implementation Details

`down_file` is created on the first failed check, before `THRESHOLD` is reached. `RECOVERED` was guarded only on `down_file`, so any outage shorter than `THRESHOLD` but longer than one `INTERVAL` produced a recovery alert with no prior outage alert.

Guard the `RECOVERED` log and alert on `last_alert_file` instead. `last_alert_file` is only written when an `UNREACHABLE` alert is actually sent, so recovery notifications now only fire when an outage was reported first. Both state files are still cleaned up regardless, so sub-threshold blips are silently discarded.

fixes #10 

---

# Post-Implementation Validation (If Needed)

## Validation Details

- Validation Date:
  16.06.2026

- Validation Performed By:
  @daverolo 

Security Testing Performed:

- [ ] Yes
- [ ] No
- [x] N/A
- [ ] Manual Testing

## Validation Notes

N/A

---

# Security Review

- [x] I confirm that I understand and have complied with all requirements outlined in the [Secure Development Guideline](https://rocklogic.sharepoint.com/sites/Intranet#secure-development-guideline).
